### PR TITLE
Fixed POP.h import

### DIFF
--- a/RCPageControl/RCPageControl.m
+++ b/RCPageControl/RCPageControl.m
@@ -31,7 +31,7 @@
  */
 
 #import "RCPageControl.h"
-#import <POP.h>
+#import <pop/POP.h>
 
 #define RCDefaultIndicatorDotBaseTag 1009
 


### PR DESCRIPTION
Original import statement was giving error:
#import <POP.h>
So I have changed it to:
#import <pop/POP.h>