### PR TITLE
Added the ability to set a shadow to indicators.

### DIFF
--- a/RCPageControl/RCPageControl.h
+++ b/RCPageControl/RCPageControl.h
@@ -58,6 +58,13 @@ typedef void (^RCCurrentPageChangedBlock)(RCPageControl *pageControl);
 @property(nonatomic) UIColor *currentPageIndicatorTintColor;    // default is [UIColor whiteColor]
 @property(nonatomic) UIColor *currentPageIndexTextTintColor;    // default is [UIColor darkTextColor]
 
+@property(nonatomic) BOOL pageIndicatorShadowEnabled;       // default is NO
+@property(nonatomic) UIColor *pageIndicatorShadowColor;     // default is [UIColor blackColor]
+@property(nonatomic) CGFloat pageIndicatorShadowRadius;     // default is 1.0f
+@property(nonatomic) CGFloat pageIndicatorShadowOpacity;    // default is 0.6f
+@property(nonatomic) CGSize pageIndicatorShadowOffset;      // default is {0.5f, 0.5f}
+
+
 @property(nonatomic) UIFont *currentPageIndexTextFont;    // default is [UIFont systemFontOfSize:0], the font size is automatically adjusts by the value of indicatorDotWidth and animationScaleFactor
 
 @property (nonatomic, copy) RCCurrentPageChangedBlock currentPageChangedBlock;   // if set, -sendActionsForControlEvents will never be called, only available for 'Touch Event' in page control, it also means you need to set non-zero frame for page control to activate 'Touch Event'

--- a/RCPageControl/RCPageControl.m
+++ b/RCPageControl/RCPageControl.m
@@ -116,7 +116,12 @@
     _pageIndicatorTintColor = [UIColor lightTextColor];
     _currentPageIndicatorTintColor = [UIColor whiteColor];
     _currentPageIndexTextTintColor = [UIColor darkTextColor];
-    
+
+    _pageIndicatorShadowColor   = [UIColor darkGrayColor];
+    _pageIndicatorShadowOpacity = 0.6f;
+    _pageIndicatorShadowRadius  = 1.0f;
+    _pageIndicatorShadowOffset  = CGSizeMake(0.5f, 0.5f);
+
     _currentPageIndexTextFont = [UIFont systemFontOfSize:0];
     
     [self loadIndicatorIndexLabel];
@@ -252,6 +257,42 @@
     if ( ![_currentPageIndexTextFont isEqual:currentPageIndexTextFont]) {
         _currentPageIndexTextFont = currentPageIndexTextFont;
         [self loadIndicatorIndexLabel];
+    }
+}
+
+
+- (void)setPageIndicatorShadowColor:(UIColor *)pageIndicatorShadowColor {
+    if ( ![_pageIndicatorShadowColor isEqual:pageIndicatorShadowColor]) {
+        _pageIndicatorShadowColor = pageIndicatorShadowColor;
+        [self _refreshIndicator:YES];
+    }
+}
+
+- (void)setPageIndicatorShadowOffset:(CGSize)pageIndicatorShadowOffset {
+    if ( !CGSizeEqualToSize(_pageIndicatorShadowOffset, pageIndicatorShadowOffset) ) {
+        _pageIndicatorShadowOffset = pageIndicatorShadowOffset;
+        [self _refreshIndicator:YES];
+    }
+}
+
+- (void)setPageIndicatorShadowRadius:(CGFloat)pageIndicatorShadowRadius {
+    if ( _pageIndicatorShadowRadius != pageIndicatorShadowRadius ) {
+        _pageIndicatorShadowRadius = pageIndicatorShadowRadius;
+        [self _refreshIndicator:YES];
+    }
+}
+
+- (void)setPageIndicatorShadowOpacity:(CGFloat)pageIndicatorShadowOpacity {
+    if ( _pageIndicatorShadowOpacity != pageIndicatorShadowOpacity ) {
+        _pageIndicatorShadowOpacity = pageIndicatorShadowOpacity;
+        [self _refreshIndicator:YES];
+    }
+}
+
+- (void)setPageIndicatorShadowEnabled:(BOOL)pageIndicatorShadowEnabled {
+    if ( _pageIndicatorShadowEnabled != pageIndicatorShadowEnabled ) {
+        _pageIndicatorShadowEnabled = pageIndicatorShadowEnabled;
+        [self _refreshIndicator:YES];
     }
 }
 
@@ -424,8 +465,15 @@
                 [dot setTag:[self _dotTagAtIndex:index]];
                 [dot setBackgroundColor:_pageIndicatorTintColor];
                 
-                [dot.layer setMasksToBounds:YES];
+                [dot.layer setMasksToBounds:NO];
                 [dot.layer setCornerRadius:dot.frame.size.height / 2];
+                
+                if ( _pageIndicatorShadowEnabled ) {
+                    [dot.layer setShadowRadius:_pageIndicatorShadowRadius];
+                    [dot.layer setShadowColor:_pageIndicatorShadowColor.CGColor];
+                    [dot.layer setShadowOffset:_pageIndicatorShadowOffset];
+                    [dot.layer setShadowOpacity:_pageIndicatorShadowOpacity];
+                }
                 
                 if ( !dot.superview) {
                     [self addSubview:dot];


### PR DESCRIPTION
Adds these methods to configure shadows to the indicators.

```
@property(nonatomic) BOOL pageIndicatorShadowEnabled;       // default is NO
@property(nonatomic) UIColor *pageIndicatorShadowColor;     // default is [UIColor blackColor]
@property(nonatomic) CGFloat pageIndicatorShadowRadius;     // default is 1.0f
@property(nonatomic) CGFloat pageIndicatorShadowOpacity;    // default is 0.6f
@property(nonatomic) CGSize pageIndicatorShadowOffset;      // default is {0.5f, 0.5f}
```